### PR TITLE
Removes dart_jsx from publish workflow

### DIFF
--- a/.github/workflows/publish-tier1.yml
+++ b/.github/workflows/publish-tier1.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/_publish-packages.yml
     with:
       tier: 1
-      packages: "dart_logging dart_node_core dart_jsx"
+      packages: "dart_logging dart_node_core"
     secrets: inherit


### PR DESCRIPTION
## TLDR;
Removes the `dart_jsx` package from the tier 1 publish workflow, streamlining the release process.

## What Does This Do?
This change updates the `publish-tier1.yml` workflow to exclude the `dart_jsx` package. This ensures that `dart_jsx` is no longer included in the automated publishing process for tier 1 packages.

## Brief Details?
The `packages` argument in the `publish-tier1.yml` workflow is modified to remove `dart_jsx`. The commit message confirms the intention to remove `dart jsx`. The branch name also reflects the removal of `dartjsx`.

## How Do The Tests Prove The Change Works?
There are no explicit tests included in the diff. It relies on the correct configuration of the publishing workflow.