### PR TITLE
Release prep 0.13.0-beta: changelogs + lock non-published packages

### DIFF
--- a/packages/dart_jsx/pubspec.yaml
+++ b/packages/dart_jsx/pubspec.yaml
@@ -1,6 +1,7 @@
 name: dart_jsx
 description: JSX transpiler for Dart - transforms JSX syntax to dart_node_react calls
 version: 0.1.0
+publish_to: none
 repository: https://github.com/user/dart_node/tree/main/packages/dart_jsx
 
 environment:

--- a/packages/dart_logging/CHANGELOG.md
+++ b/packages/dart_logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0-beta
+
+- Maintenance release; no functional changes
+
 ## 0.12.0-beta
 
 - Maintenance release

--- a/packages/dart_node_better_sqlite3/CHANGELOG.md
+++ b/packages/dart_node_better_sqlite3/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0-beta
+
+- Maintenance release; no functional changes
+
 ## 0.12.0-beta
 
 - Maintenance release

--- a/packages/dart_node_core/CHANGELOG.md
+++ b/packages/dart_node_core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.0-beta
+
+- Add filesystem (`fs`) bindings
+- Add child process interop
+
 ## 0.12.0-beta
 
 - Improved documentation for core extensions

--- a/packages/dart_node_coverage/pubspec.yaml
+++ b/packages/dart_node_coverage/pubspec.yaml
@@ -1,6 +1,7 @@
 name: dart_node_coverage
 description: Coverage collection for Dart tests running on Node.js (dart2js)
 version: 0.9.0-beta
+publish_to: none
 repository: https://github.com/MelbourneDeveloper/dart_node
 
 environment:

--- a/packages/dart_node_express/CHANGELOG.md
+++ b/packages/dart_node_express/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0-beta
+
+- Maintenance release; no functional changes
+
 ## 0.12.0-beta
 
 - Maintenance release

--- a/packages/dart_node_mcp/CHANGELOG.md
+++ b/packages/dart_node_mcp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.0-beta
+
+- Add streamable HTTP transport
+- Additional MCP server capabilities
+
 ## 0.12.0-beta
 
 - Maintenance release

--- a/packages/dart_node_react/CHANGELOG.md
+++ b/packages/dart_node_react/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0-beta
+
+- Maintenance release; no functional changes
+
 ## 0.12.0-beta
 
 - Maintenance release

--- a/packages/dart_node_react_native/CHANGELOG.md
+++ b/packages/dart_node_react_native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0-beta
+
+- Maintenance release; no functional changes
+
 ## 0.12.0-beta
 
 - Maintenance release

--- a/packages/dart_node_vsix/pubspec.yaml
+++ b/packages/dart_node_vsix/pubspec.yaml
@@ -1,6 +1,7 @@
 name: dart_node_vsix
 description: VSCode extension API bindings for Dart via dart:js_interop
 version: 0.1.0
+publish_to: none
 
 environment:
   sdk: ^3.10.0

--- a/packages/dart_node_ws/CHANGELOG.md
+++ b/packages/dart_node_ws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0-beta
+
+- Maintenance release; internal test improvements
+
 ## 0.12.0-beta
 
 - Maintenance release

--- a/packages/reflux/CHANGELOG.md
+++ b/packages/reflux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0-beta
+
+- Maintenance release; no functional changes
+
 ## 0.12.0-beta
 
 - Enhanced test coverage


### PR DESCRIPTION
## TLDR
Prepares the `0.13.0-beta` release: adds changelog entries for the 9 publishable packages and locks the non-published packages so release tagging can't touch them.

## What Was Changed?
- **CHANGELOG `## 0.13.0-beta`** for all 9 publishable packages. Only three changed since `0.12.0-beta`: `dart_node_core` (filesystem `fs` bindings + child-process interop), `dart_node_mcp` (streamable HTTP transport + server capabilities), `dart_node_ws` (test-only). The other six are maintenance.
- **`publish_to: none`** added to `dart_jsx`, `dart_node_vsix`, `dart_node_coverage` — they had no publish guard and are not in the release config, so this guarantees the `Release/0.13.0-beta` tag can never publish or alter them. Versions kept as placeholders.

## Why
`0.12.0-beta` is already live on pub.dev; `0.13.0-beta` is the next version. The release skill requires a `## 0.13.0-beta` changelog entry per publishable package before tagging. Package version bumps are intentionally NOT made here — CI stamps them on the ephemeral release branch from the tag.

## Breaking Changes
- [x] None — changelog + publish-guard metadata only.