### PR TITLE
Remove Too Many Cooks from homepage; path-filter CI for website-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,35 @@ env:
   SERVER_BINARY: build/bin/server_node.js
 
 jobs:
+  # Change detection ([CI-PATH-FILTER]). Website-only PRs skip the Dart
+  # lint/test/build jobs; code-only PRs skip the website job. Job-level `if`
+  # skips report a "skipped" conclusion that SATISFIES required status checks —
+  # unlike workflow-level `paths:` filters, which leave required checks pending
+  # forever and block the merge. So we gate here, never with `on: paths`.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      website: ${{ steps.filter.outputs.website }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            website:
+              - 'website/**'
+            code:
+              - '!website/**'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -88,7 +113,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: lint
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -143,7 +169,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: test
+    needs: [changes, test]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -169,6 +196,8 @@ jobs:
     name: Website Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.website == 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -375,15 +375,6 @@ ReactElement counter() {
           <a href="https://github.com/MelbourneDeveloper/dart_node/tree/main/packages/dart_node_vsix" target="_blank" rel="noopener noreferrer" class="pub-link">Source &rarr;</a>
         </div>
       </div>
-
-      <div class="feature-card">
-        <div class="feature-icon" style="background: #8e44ad;">T</div>
-        <h3>Too Many Cooks</h3>
-        <p>Multi-agent coordination MCP server, originally built with dart_node_mcp. It has moved to its own home and is no longer part of this repo.</p>
-        <div class="feature-links">
-          <a href="https://tmc-mcp.dev" target="_blank" rel="noopener noreferrer" class="pub-link">tmc-mcp.dev &rarr;</a>
-        </div>
-      </div>
     </div>
   </div>
 </section>

--- a/website/src/zh/index.njk
+++ b/website/src/zh/index.njk
@@ -247,13 +247,6 @@ ReactElement counter() {
         <p>VSCode 扩展 API 绑定，使用 Dart 构建 Visual Studio Code 扩展。</p>
         <a href="https://github.com/MelbourneDeveloper/dart_node/tree/main/packages/dart_node_vsix" target="_blank" rel="noopener noreferrer">在 GitHub 查看源码 &rarr;</a>
       </div>
-
-      <div class="feature-card">
-        <div class="feature-icon" style="background: #8e44ad;">T</div>
-        <h3>Too Many Cooks</h3>
-        <p>多 AI 代理协调 MCP 服务器，最初使用 dart_node_mcp 构建。它已迁移到独立站点，不再是本仓库的一部分。</p>
-        <a href="https://tmc-mcp.dev" target="_blank" rel="noopener noreferrer">tmc-mcp.dev &rarr;</a>
-      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## TLDR
Removes the Too Many Cooks feature card from the homepage (it moved to tmc-mcp.dev and left this repo) and path-filters CI so website-only PRs no longer run the full Dart lint/test/build suite.

## What Was Changed or Deleted?
- **Homepage (en + zh):** deleted the `Too Many Cooks` feature card from `website/src/index.njk` and `website/src/zh/index.njk`. TMC is no longer an example of this project.
- **docs/mcp (unchanged this PR, already correct):** the `docs/mcp` pages retain a short note that TMC has moved to [tmc-mcp.dev](https://tmc-mcp.dev) and is no longer part of this repository — satisfying "other pages must point to tmc-mcp.dev explaining it moved."
- **CI path filtering:** added a `changes` detection job (`dorny/paths-filter`) and gated `lint`/`test`/`build` behind `needs.changes.outputs.code == 'true'` and `website` behind `needs.changes.outputs.website == 'true'`. Website-only PRs skip the Dart suite; code-only PRs skip the website job.

## How Do The Automated Tests Prove It Works?
- All **108 Playwright website tests pass** locally after the change, including `pages.spec.js › Homepage › homepage loads with all essential elements` — the homepage still renders correctly with the card gone.
- Verified the generated output: `_site/index.html` and `_site/zh/index.html` contain **zero** occurrences of "Too Many Cooks"/"tmc", while `_site/docs/mcp/index.html` and `_site/zh/docs/mcp/index.html` still link to `tmc-mcp.dev`.
- Job-level `if` skips (not workflow-level `paths:`) are used deliberately so skipped jobs report a "skipped" conclusion that satisfies required status checks rather than leaving them pending and blocking the merge.

## Breaking Changes
- [x] None